### PR TITLE
Update MySQL Port and add root user for local machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grouptopics w/ Vagrant
 
-A basic Ubuntu 11.04 Vagrant setup for [Grouptopics](https://github.com/sdphp/grouptopics.org), Apache 2, MySQL 5.5.29, PHP 5.3.10.
+A basic Ubuntu 12.04 Vagrant setup for [Grouptopics](https://github.com/sdphp/grouptopics.org), Apache 2, MySQL 5.5.29, PHP 5.3.10.
 
 ## Requirements
 
@@ -51,12 +51,15 @@ Vagrant is [very well documented](http://vagrantup.com/v1/docs/index.html) but h
 
 ##### Virtual Machine Specifications #####
 
-* OS     - Ubuntu 11.04
+* OS     - Ubuntu 12.04
 * Apache - 2.2.22
-* PHP    - 5.3.2
-* MySQL  - 5.5.28
+* PHP    - 5.3.10
+* MySQL  - 5.5.29
 
 Phpmyadmin is available [http://dev.gt:8080/phpmyadmin/](http://dev.gt:8080/phpmyadmin/). User `root`, Password `root`
+Database can be connected to from host system using port 8086 
+
+        mysql -h dev.gt -P 8086 -u root -p
 
 After getting all this set up, read the site readme [here](https://github.com/sdphp/grouptopics.org/blob/master/site/README.md).
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant::Config.run do |config|
   end
 
   config.vm.forward_port(80, 8080)
-  config.vm.forward_port(3306, 3306)
+  config.vm.forward_port(3306, 8086)
   
   config.vm.share_folder("v-root", "/vagrant", ".", :extra => 'dmode=777,fmode=777')
 end

--- a/my-recipes/cookbooks/vagrant_main/recipes/default.rb
+++ b/my-recipes/cookbooks/vagrant_main/recipes/default.rb
@@ -49,7 +49,9 @@ execute "add-admin-user" do
       "CREATE USER 'myadmin'@'localhost' IDENTIFIED BY 'myadmin';" +
       "GRANT ALL PRIVILEGES ON *.* TO 'myadmin'@'localhost' WITH GRANT OPTION;" +
       "CREATE USER 'myadmin'@'%' IDENTIFIED BY 'myadmin';" +
-      "GRANT ALL PRIVILEGES ON *.* TO 'myadmin'@'%' WITH GRANT OPTION;\" " +
+      "GRANT ALL PRIVILEGES ON *.* TO 'myadmin'@'%' WITH GRANT OPTION;" +
+      "CREATE USER 'root'@'%' IDENTIFIED BY 'root';" +
+      "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;\" " +
       "mysql"
   action :run
   only_if { `/usr/bin/mysql -u root -p#{node[:mysql][:server_root_password]} -D mysql -r -N -e \"SELECT COUNT(*) FROM user where user='myadmin' and host='localhost'"`.to_i == 0 }


### PR DESCRIPTION
This patch allows you to access the MySQL running on the vargrant machine from the local machine on port 8086 using user `root` password `root` from your command line or your favorite MySQL tool running on your local machine.

`mysql -h dev.gt -P 8086 -u root -p`
